### PR TITLE
Fix encoding issue in Python viewport warning message

### DIFF
--- a/tools/python_editor/aartze_editor/viewport.py
+++ b/tools/python_editor/aartze_editor/viewport.py
@@ -191,7 +191,7 @@ class GLViewport(QtOpenGLWidgets.QOpenGLWidget):
             if not eng and _eng_err:
                 p = QtGui.QPainter(self)
                 p.setPen(QtGui.QPen(QtGui.QColor('#f59e0b')))
-                p.drawText(12, 18, 'Engine module not loaded – using Python fallback')
+                p.drawText(12, 18, 'Engine module not loaded - using Python fallback')
                 p.end()
 
         # Axis triad overlay (Blender-like, top-right with circles)


### PR DESCRIPTION
## Summary
- replace Windows-1252 dash with ASCII hyphen in viewport fallback warning

## Testing
- `python -m py_compile tools/python_editor/aartze_editor/viewport.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc2ebb57fc832da73063f809c4d78b